### PR TITLE
Fix `claypoole/pmap` false positive lint errors

### DIFF
--- a/configs/org.clj-commons/claypoole/deps.edn
+++ b/configs/org.clj-commons/claypoole/deps.edn
@@ -6,4 +6,11 @@
   :build ;; added by neil
   {:deps {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}
-   :ns-default build}}}
+   :ns-default build}
+  :test {:extra-paths ["test"]
+         :extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.09.27"}
+                      com.climate/claypoole {:mvn/version "1.1.4"}
+                      io.github.cognitect-labs/test-runner {:git/tag "v0.5.0"
+                                                            :git/sha "b3fd0d2"}}
+         :main-opts ["-m" "cognitect.test-runner"]
+         :exec-fn cognitect.test-runner.api/test}}}

--- a/configs/org.clj-commons/claypoole/resources/clj-kondo.exports/clj-kondo/claypoole/clj_kondo/claypoole.clj
+++ b/configs/org.clj-commons/claypoole/resources/clj-kondo.exports/clj-kondo/claypoole/clj_kondo/claypoole.clj
@@ -7,11 +7,10 @@
   (fn [{:keys [:node]}]
     (let [[pool & body] (rest (:children node))
           new-node (api/list-node
-                    [(api/token-node token)
+                    [(api/token-node 'do)
+                     pool
                      (api/list-node
-                      (list* (api/token-node 'do)
-                             pool
-                             body))])]
+                      (cons (api/token-node token) body))])]
       {:node (with-meta new-node
                (meta node))})))
 

--- a/configs/org.clj-commons/claypoole/test/clj_kondo/claypoole_test.clj
+++ b/configs/org.clj-commons/claypoole/test/clj_kondo/claypoole_test.clj
@@ -1,12 +1,20 @@
-(ns claypoole-test
-  (:require
-   [com.climate.claypoole :as cp]))
+(ns clj-kondo.claypoole-test
+  (:require [clj-kondo.core :as clj-kondo]
+            [clojure.test :refer :all]
+            [com.climate.claypoole :as cp]))
+
+(deftest no-errors
+  (let [errors (->> (clj-kondo/run! {:lint ["test/clj_kondo/claypoole_test.clj"]
+                                     :cache false})
+                    :findings
+                    (filter #(= :error (:level %)))
+                    (mapv #(select-keys % [:row :type :level :message])))]
+    (is (empty? errors))))
 
 (def pool (cp/threadpool 8))
-(def coll [1 2 3])
+(def coll (range 10))
 
-(defn -main
-  [& _]
+(comment
   ;; future
   (let [x 1]
     (cp/future pool (println "Hi from future: " x)))
@@ -78,5 +86,4 @@
   (cp/upfor 8) ;; arity warning with correct location
 
   (let [x 8] ;; binding is used
-    (cp/upfor x [y coll] (println y)))
-  )
+    (cp/upfor x [y coll] (println y))))


### PR DESCRIPTION
Fixes #5 

- Add an automated test that just asserts that the test file has no lint errors
- Make the test fail by passing a sequence as `coll` instead of a function
- Fix the failing test by changing the `pool-and-body` hook code.
   - Previously we were turning `(cp/pmap pool f coll)` into `(map (do pool f coll))`, which is a lint error because that effectively becomes `(map coll)`.
   - Now we transform it to `(do pool (map f coll))`.
- This also affects a number of other functions, like `upmap` and `future`. I believe they should be correct though
   - e.g. `(cp/future pool & body)` was previously `(future (do pool & body))`, now it's `(do pool (future & body))`

Note that we're not doing any linting of the `pool` value, which we ideally should. But that was the case before this PR as well.